### PR TITLE
✨ 210830: GameInfo 컴포넌트 기능 구현

### DIFF
--- a/src/components/About/GameInfo/GameInfo.style.ts
+++ b/src/components/About/GameInfo/GameInfo.style.ts
@@ -7,7 +7,7 @@ export const GameInfoWrapper = styled.section`
   justify-content: center;
   width: 100%;
   padding: 20rem 0 5rem 0;
-  background: ${({ theme }) => theme.palette.backgroundColors["dark"]};
+  background: ${({ theme }) => theme.palette.backgroundColors.dark};
 `;
 
 export const GameInfoContainer = styled.div`
@@ -51,7 +51,7 @@ export const GameInfoBox = styled.div`
   display: flex;
   width: 100%;
   padding: 4.1rem 9.5rem;
-  background: ${({ theme }) => theme.palette.backgroundColors["main"]};
+  background: ${({ theme }) => theme.palette.backgroundColors.main};
 `;
 
 export const GameInfoBoxContent = styled.div`

--- a/src/components/About/GameInfo/GameInfo.style.ts
+++ b/src/components/About/GameInfo/GameInfo.style.ts
@@ -1,5 +1,3 @@
-import Image from "next/image";
-
 import styled from "styled-components";
 
 export const GameInfoWrapper = styled.section`

--- a/src/components/About/GameInfo/GameInfo.style.ts
+++ b/src/components/About/GameInfo/GameInfo.style.ts
@@ -1,0 +1,15 @@
+import Image from "next/image";
+
+import styled from "styled-components";
+
+export const GameInfoWrapper = styled.section``;
+
+export const GameInfoHeader = styled.div``;
+
+export const GameInfoContent = styled.div``;
+
+export const GameInfoTitle = styled.h3``;
+
+export const GameInfoImg = styled.div``;
+
+export const GameInfoBox = styled.div``;

--- a/src/components/About/GameInfo/GameInfo.style.ts
+++ b/src/components/About/GameInfo/GameInfo.style.ts
@@ -2,14 +2,58 @@ import Image from "next/image";
 
 import styled from "styled-components";
 
-export const GameInfoWrapper = styled.section``;
+export const GameInfoWrapper = styled.section`
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  padding: 20rem 0 5rem 0;
+  background: ${({ theme }) => theme.palette.backgroundColors["dark"]};
+`;
 
-export const GameInfoHeader = styled.div``;
+export const GameInfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-width: 102.4rem;
+`;
 
-export const GameInfoContent = styled.div``;
+export const GameInfoHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 3.8rem;
+`;
 
-export const GameInfoTitle = styled.h3``;
+export const GameInfoContent = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
 
-export const GameInfoImg = styled.div``;
+export const GameInfoTitle = styled.h3`
+  font-size: 3.2rem;
+  font-weight: 700;
+  margin-bottom: 5.5rem;
+  color: ${({ theme }) => theme.palette.grayScale[100]};
+`;
+export const GameInfoHashTags = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  max-width: 45rem;
+`;
 
-export const GameInfoBox = styled.div``;
+export const GameInfoImg = styled.div`
+  width: 46rem;
+  height: 21.5rem;
+  border-radius: 1rem;
+  background: ${({ theme }) => theme.palette.grayScale[300]};
+`;
+
+export const GameInfoBox = styled.div`
+  display: flex;
+  width: 100%;
+  padding: 4.1rem 9.5rem;
+  background: ${({ theme }) => theme.palette.backgroundColors["main"]};
+`;
+
+export const GameInfoBoxContent = styled.div`
+  display: flex;
+  flex-direction: column;
+`;

--- a/src/components/About/GameInfo/GameInfo.style.ts
+++ b/src/components/About/GameInfo/GameInfo.style.ts
@@ -25,25 +25,26 @@ export const GameInfoHeader = styled.div`
 export const GameInfoContent = styled.div`
   display: flex;
   flex-direction: column;
+  max-width: 45rem;
 `;
 
 export const GameInfoTitle = styled.h3`
   font-size: 3.2rem;
   font-weight: 700;
+  line-height: 4rem;
   margin-bottom: 5.5rem;
   color: ${({ theme }) => theme.palette.grayScale[100]};
 `;
 export const GameInfoHashTags = styled.div`
   display: flex;
   flex-wrap: wrap;
-  max-width: 45rem;
 `;
 
-export const GameInfoImg = styled.div`
+export const GameInfoImg = styled.div<{ url: string }>`
   width: 46rem;
   height: 21.5rem;
   border-radius: 1rem;
-  background: ${({ theme }) => theme.palette.grayScale[300]};
+  background-image: url(${({ url }) => url});
 `;
 
 export const GameInfoBox = styled.div`

--- a/src/components/About/GameInfo/GameInfo.tsx
+++ b/src/components/About/GameInfo/GameInfo.tsx
@@ -5,34 +5,44 @@ import GameInfoMeta from "./GameInfoMeta";
 
 import {
   GameInfoWrapper,
+  GameInfoContainer,
   GameInfoHeader,
   GameInfoContent,
   GameInfoTitle,
+  GameInfoHashTags,
   GameInfoImg,
   GameInfoBox,
+  GameInfoBoxContent,
 } from "./GameInfo.style";
 
 const dummyData = ["액션", "캐주얼", "인디"];
 
 const GameInfo = () => {
-  const [isTooltipShow, setIsTooltipShow] = useState<boolean>(false);
-
   return (
     <GameInfoWrapper>
-      <GameInfoHeader>
-        <GameInfoContent>
-          <GameInfoTitle>OverCooked2 !</GameInfoTitle>
-          {dummyData.map((text, idx) => (
-            <GameInfoHashtag key={idx} text={text} />
-          ))}
-        </GameInfoContent>
+      <GameInfoContainer>
+        <GameInfoHeader>
+          <GameInfoContent>
+            <GameInfoTitle>OverCooked2 !</GameInfoTitle>
+            <GameInfoHashTags>
+              {dummyData.map((text, idx) => (
+                <GameInfoHashtag key={idx} text={text} />
+              ))}
+            </GameInfoHashTags>
+          </GameInfoContent>
+          <GameInfoImg />
+        </GameInfoHeader>
 
-        <GameInfoImg />
-      </GameInfoHeader>
-
-      <GameInfoBox>
-        <GameInfoMeta title={"게임장르"} desc={"액션, 캐주얼, 인디"} />
-      </GameInfoBox>
+        <GameInfoBox>
+          <GameInfoBoxContent>
+            <GameInfoMeta title={"게임장르"} desc={"액션, 캐주얼, 인디"} />
+            <GameInfoMeta title={"게임장르"} desc={"액션, 캐주얼, 인디"} />
+          </GameInfoBoxContent>
+          <GameInfoBoxContent>
+            <GameInfoMeta title={"게임장르"} desc={"액션, 캐주얼, 인디"} />
+          </GameInfoBoxContent>
+        </GameInfoBox>
+      </GameInfoContainer>
     </GameInfoWrapper>
   );
 };

--- a/src/components/About/GameInfo/GameInfo.tsx
+++ b/src/components/About/GameInfo/GameInfo.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 
+import { AboutPageProps } from "pages/about/[id]";
+
 import GameInfoHashtag from "./GameInfoHashtag";
 import GameInfoMeta from "./GameInfoMeta";
 
@@ -15,31 +17,31 @@ import {
   GameInfoBoxContent,
 } from "./GameInfo.style";
 
-const dummyData = ["액션", "캐주얼", "인디"];
+const GameInfo = ({ item }: AboutPageProps) => {
+  const { name, genres, release_date, short_description, header_image } = item;
 
-const GameInfo = () => {
   return (
     <GameInfoWrapper>
       <GameInfoContainer>
         <GameInfoHeader>
           <GameInfoContent>
-            <GameInfoTitle>OverCooked2 !</GameInfoTitle>
+            <GameInfoTitle>{name ? name : "이름 없음"}</GameInfoTitle>
             <GameInfoHashTags>
-              {dummyData.map((text, idx) => (
+              {genres.map((text, idx) => (
                 <GameInfoHashtag key={idx} text={text} />
               ))}
             </GameInfoHashTags>
           </GameInfoContent>
-          <GameInfoImg />
+          <GameInfoImg url={header_image} />
         </GameInfoHeader>
 
         <GameInfoBox>
           <GameInfoBoxContent>
-            <GameInfoMeta title={"게임장르"} desc={"액션, 캐주얼, 인디"} />
-            <GameInfoMeta title={"게임장르"} desc={"액션, 캐주얼, 인디"} />
+            <GameInfoMeta title={"게임 장르"} desc={genres.join(", ")} />
+            <GameInfoMeta title={"출시 날짜"} desc={release_date} />
           </GameInfoBoxContent>
           <GameInfoBoxContent>
-            <GameInfoMeta title={"게임장르"} desc={"액션, 캐주얼, 인디"} />
+            <GameInfoMeta title={"게임 소개"} desc={short_description} />
           </GameInfoBoxContent>
         </GameInfoBox>
       </GameInfoContainer>

--- a/src/components/About/GameInfo/GameInfo.tsx
+++ b/src/components/About/GameInfo/GameInfo.tsx
@@ -1,0 +1,40 @@
+import { useState } from "react";
+
+import GameInfoHashtag from "./GameInfoHashtag";
+import GameInfoMeta from "./GameInfoMeta";
+
+import {
+  GameInfoWrapper,
+  GameInfoHeader,
+  GameInfoContent,
+  GameInfoTitle,
+  GameInfoImg,
+  GameInfoBox,
+} from "./GameInfo.style";
+
+const dummyData = ["액션", "캐주얼", "인디"];
+
+const GameInfo = () => {
+  const [isTooltipShow, setIsTooltipShow] = useState<boolean>(false);
+
+  return (
+    <GameInfoWrapper>
+      <GameInfoHeader>
+        <GameInfoContent>
+          <GameInfoTitle>OverCooked2 !</GameInfoTitle>
+          {dummyData.map((text, idx) => (
+            <GameInfoHashtag key={idx} text={text} />
+          ))}
+        </GameInfoContent>
+
+        <GameInfoImg />
+      </GameInfoHeader>
+
+      <GameInfoBox>
+        <GameInfoMeta title={"게임장르"} desc={"액션, 캐주얼, 인디"} />
+      </GameInfoBox>
+    </GameInfoWrapper>
+  );
+};
+
+export default GameInfo;

--- a/src/components/About/GameInfo/GameInfoHashtag/GameInfoHashtag.style.ts
+++ b/src/components/About/GameInfo/GameInfoHashtag/GameInfoHashtag.style.ts
@@ -1,0 +1,7 @@
+import styled from "styled-components";
+
+export const GameInfoHashTagWrapper = styled.span`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;

--- a/src/components/About/GameInfo/GameInfoHashtag/GameInfoHashtag.style.ts
+++ b/src/components/About/GameInfo/GameInfoHashtag/GameInfoHashtag.style.ts
@@ -3,5 +3,13 @@ import styled from "styled-components";
 export const GameInfoHashTagWrapper = styled.span`
   display: flex;
   align-items: center;
-  justify-content: center;
+
+  padding: 0.3rem 1.9rem;
+  border-radius: 14px;
+  background: #836eff;
+  margin: 0 1rem 1rem 0;
+
+  font-size: 1.4rem;
+  font-weight: 400;
+  color: ${({ theme }) => theme.palette.grayScale[100]};
 `;

--- a/src/components/About/GameInfo/GameInfoHashtag/GameInfoHashtag.tsx
+++ b/src/components/About/GameInfo/GameInfoHashtag/GameInfoHashtag.tsx
@@ -1,0 +1,11 @@
+import { GameInfoHashTagWrapper } from "./GameInfoHashtag.style";
+
+interface GameInfoHashtagProps {
+  text: string;
+}
+
+const GameInfoHashtag = ({ text }: GameInfoHashtagProps) => {
+  return <GameInfoHashTagWrapper>{text}</GameInfoHashTagWrapper>;
+};
+
+export default GameInfoHashtag;

--- a/src/components/About/GameInfo/GameInfoHashtag/index.ts
+++ b/src/components/About/GameInfo/GameInfoHashtag/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./GameInfoHashtag";

--- a/src/components/About/GameInfo/GameInfoMeta/GameInfoMeta.style.ts
+++ b/src/components/About/GameInfo/GameInfoMeta/GameInfoMeta.style.ts
@@ -1,0 +1,10 @@
+import styled from "styled-components";
+
+export const GameInfoMetaWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const GameInfoMetaTitle = styled.span``;
+export const GameInfoMetaDesc = styled.span``;

--- a/src/components/About/GameInfo/GameInfoMeta/GameInfoMeta.style.ts
+++ b/src/components/About/GameInfo/GameInfoMeta/GameInfoMeta.style.ts
@@ -2,9 +2,24 @@ import styled from "styled-components";
 
 export const GameInfoMetaWrapper = styled.div`
   display: flex;
-  align-items: center;
-  justify-content: center;
+  align-items: flex-start;
+
+  & + & {
+    margin-top: 2.5rem;
+  }
 `;
 
-export const GameInfoMetaTitle = styled.span``;
-export const GameInfoMetaDesc = styled.span``;
+export const GameInfoMetaTitle = styled.span`
+  font-size: 1.8rem;
+  font-weight: 400;
+  margin-right: 1.8rem;
+  color: ${({ theme }) => theme.palette.primary["light"]};
+`;
+export const GameInfoMetaDesc = styled.span`
+  font-size: 1.4rem;
+  font-weight: 400;
+  line-height: 1.9rem;
+  max-width: 30rem;
+  min-width: 30rem;
+  color: ${({ theme }) => theme.palette.grayScale[200]};
+`;

--- a/src/components/About/GameInfo/GameInfoMeta/GameInfoMeta.tsx
+++ b/src/components/About/GameInfo/GameInfoMeta/GameInfoMeta.tsx
@@ -1,0 +1,21 @@
+import {
+  GameInfoMetaWrapper,
+  GameInfoMetaTitle,
+  GameInfoMetaDesc,
+} from "./GameInfoMeta.style";
+
+interface GameInfoMetaProps {
+  title: string;
+  desc: string;
+}
+
+const GameInfoMeta = ({ title, desc }: GameInfoMetaProps) => {
+  return (
+    <GameInfoMetaWrapper>
+      <GameInfoMetaTitle>{title}</GameInfoMetaTitle>
+      <GameInfoMetaDesc>{desc}</GameInfoMetaDesc>
+    </GameInfoMetaWrapper>
+  );
+};
+
+export default GameInfoMeta;

--- a/src/components/About/GameInfo/GameInfoMeta/index.ts
+++ b/src/components/About/GameInfo/GameInfoMeta/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./GameInfoMeta";

--- a/src/components/About/GameInfo/index.ts
+++ b/src/components/About/GameInfo/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./GameInfo";

--- a/src/components/Main/Roulette/RouletteKeyword/RouletteKeyword.style.ts
+++ b/src/components/Main/Roulette/RouletteKeyword/RouletteKeyword.style.ts
@@ -21,7 +21,7 @@ export const KeywordItem = styled.button<{ isSelected: boolean }>`
   background: ${({ theme, isSelected }) =>
     isSelected
       ? theme.palette.primary.main
-      : theme.palette.backgroundColors["light"]};
+      : theme.palette.backgroundColors.light};
   color: ${({ theme, isSelected }) =>
     isSelected ? theme.palette.grayScale[100] : theme.palette.grayScale[600]};
 `;

--- a/src/components/Main/Roulette/RouletteKeyword/RouletteKeyword.style.ts
+++ b/src/components/Main/Roulette/RouletteKeyword/RouletteKeyword.style.ts
@@ -21,7 +21,7 @@ export const KeywordItem = styled.button<{ isSelected: boolean }>`
   background: ${({ theme, isSelected }) =>
     isSelected
       ? theme.palette.primary.main
-      : theme.palette.backgroundColors[100]};
+      : theme.palette.backgroundColors["light"]};
   color: ${({ theme, isSelected }) =>
     isSelected ? theme.palette.grayScale[100] : theme.palette.grayScale[600]};
 `;

--- a/src/components/PageWrapper/PageWrapper.style.ts
+++ b/src/components/PageWrapper/PageWrapper.style.ts
@@ -1,0 +1,8 @@
+import styled from "styled-components";
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-height: 100vh;
+`;

--- a/src/components/PageWrapper/PageWrapper.tsx
+++ b/src/components/PageWrapper/PageWrapper.tsx
@@ -1,0 +1,11 @@
+import { Wrapper } from "./PageWrapper.style";
+
+interface PageWrapperProps {
+  children: JSX.Element;
+}
+
+const PageWrapper = ({ children }: PageWrapperProps) => {
+  return <Wrapper>{children}</Wrapper>;
+};
+
+export default PageWrapper;

--- a/src/components/PageWrapper/index.ts
+++ b/src/components/PageWrapper/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./PageWrapper";

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from "styled-components";
 import GlobalStyle from "style/GlobalStyle";
 import theme from "style/theme";
 import Header from "components/Header";
+import PageWrapper from "components/PageWrapper";
 
 class MyApp extends App {
   render() {
@@ -14,7 +15,9 @@ class MyApp extends App {
       <ThemeProvider {...{ theme }}>
         <RecoilRoot>
           <Header />
-          <Component {...pageProps} />
+          <PageWrapper>
+            <Component {...pageProps} />
+          </PageWrapper>
           <GlobalStyle />
         </RecoilRoot>
       </ThemeProvider>

--- a/src/pages/about/[id].tsx
+++ b/src/pages/about/[id].tsx
@@ -17,7 +17,7 @@ export interface AboutPageProps {
 }
 
 const AboutPage: NextPage<AboutPageProps> = ({ item }) => {
-  return <GameInfo item={item} />;
+  return <GameInfo {...{ item }} />;
 };
 
 AboutPage.getInitialProps = async (ctx) => {

--- a/src/pages/about/[id].tsx
+++ b/src/pages/about/[id].tsx
@@ -1,31 +1,31 @@
-import React from "react";
 import { NextPage } from "next";
 import Axios from "axios";
 
 import GameInfo from "components/About/GameInfo";
 
-type AboutPageProps = {
+export interface AboutPageProps {
   item: {
     id: number;
-    //...
+    name: any;
+    short_description: string;
+    header_image: string;
+    release_date: string;
+    genres: [];
+    screenshots: [];
+    movies: [];
   };
-};
+}
 
 const AboutPage: NextPage<AboutPageProps> = ({ item }) => {
-  return (
-    <>
-      <GameInfo />
-    </>
-  );
+  return <GameInfo item={item} />;
 };
 
 AboutPage.getInitialProps = async (ctx) => {
   const id = ctx.query.id;
 
-  //test API
-  const apiUrl = `http://makeup-api.herokuapp.com/api/v1/products/${id}.json`;
+  const apiUrl = `http://3.13.108.233:8080/api/detail/${id}`;
   const res = await Axios.get(apiUrl);
-  const data = res.data;
+  const data = res.data.data;
 
   return { item: data };
 };

--- a/src/pages/about/[id].tsx
+++ b/src/pages/about/[id].tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { NextPage } from "next";
-
 import Axios from "axios";
+
+import GameInfo from "components/About/GameInfo";
 
 type AboutPageProps = {
   item: {
@@ -11,7 +12,11 @@ type AboutPageProps = {
 };
 
 const AboutPage: NextPage<AboutPageProps> = ({ item }) => {
-  return <h3>Game Info {item.id}</h3>;
+  return (
+    <>
+      <GameInfo />
+    </>
+  );
 };
 
 AboutPage.getInitialProps = async (ctx) => {

--- a/src/style/GlobalStyle.ts
+++ b/src/style/GlobalStyle.ts
@@ -14,6 +14,7 @@ const GlobalStyle = createGlobalStyle`
 
   body {
     min-width: 1024px;
+    background-color:#161623;
   }
 `;
 

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -17,9 +17,9 @@ const palette = {
     700: "#000000",
   },
   backgroundColors: {
-    100: "#F6F6F6",
-    200: "#F5F4F3",
-    300: "0F0F15",
+    light: "#F6F6F6",
+    dark: "#0F0F15",
+    main: "#161623",
   },
 };
 const devides = {

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -19,6 +19,7 @@ const palette = {
   backgroundColors: {
     100: "#F6F6F6",
     200: "#F5F4F3",
+    300: "0F0F15",
   },
 };
 const devides = {


### PR DESCRIPTION
## What is this PR? 🔍

#17 에 의해 about 페이지의 첫번째 섹션 `GameInfo` 컴포넌트 기능 구현 완료

## Major Fix 🔌
- GameInfo 컴포넌트
- PageWrapper 컴포넌트  (해당 컴포넌트에서 padding-top은 제외시켜놨으며, 이유는 커밋 desc에 남겨놨습니다.)

## Minor Fix 🛠
- body 태그의 `background-color` 추가
- `theme.ts`의 `backgrounds` 수정 ( 숫자값->string값 )