### PR TITLE
🐛 210913 이미지 깜빡거림 수정, 상세정보로 가기 다국어 처리

### DIFF
--- a/public/locales/en/main.json
+++ b/public/locales/en/main.json
@@ -3,6 +3,7 @@
   "main_roulette_subtitle": "Click on keywords to get a random recommended game!",
   "main_roulette_bubble_title": "Random Game Recommender Guide",
   "main_roulette_bubble_content": "Jampick's indie chip means an indie game.\n\nSelect up to 6 keywords at the bottom\n and get a random game recommendation.",
+  "main_roulette_game_info": "View game details",
   "main_carousel_title": "How about this indiechip?",
   "main_carousel_card_tag_free": "Free"
 }

--- a/public/locales/ko/main.json
+++ b/public/locales/ko/main.json
@@ -3,6 +3,7 @@
   "main_roulette_subtitle": "키워드를 클릭해서 랜덤으로 추천 게임을 받아보세요!",
   "main_roulette_bubble_title": "랜덤 게임 추천기 안내",
   "main_roulette_bubble_content": "잼픽의 인디칩은 인디게임을 의미합니다.\n\n하단의 키워드를 최대 6개까지 선택하여 랜덤\n으로 게임을 추천 받아보세요.",
+  "main_roulette_game_info": "게임 상세보기",
   "main_carousel_title": "이런 인디칩 어때요?",
   "main_carousel_card_tag_free": "무료"
 }

--- a/src/components/Main/Roulette/RoulettePlay/RoulettePlayContent/RoulettePlayContent.style.ts
+++ b/src/components/Main/Roulette/RoulettePlay/RoulettePlayContent/RoulettePlayContent.style.ts
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import Image from "next/image";
 
 export const RoulettePlayContentWrapper = styled.div`
   margin: 0 1.9rem;
@@ -140,4 +141,12 @@ export const RoulettePlayContentBtn = styled.span`
   border: 2px solid #c7c7c7;
   border-radius: 5px;
   padding: 0.15rem 1.5rem;
+`;
+
+export const RoulettePlayContentImage = styled(Image)<{
+  width: number;
+  height: number;
+}>`
+  width: ${({ width }) => width}px;
+  height: ${({ height }) => height}px;
 `;

--- a/src/components/Main/Roulette/RoulettePlay/RoulettePlayContent/RoulettePlayContent.tsx
+++ b/src/components/Main/Roulette/RoulettePlay/RoulettePlayContent/RoulettePlayContent.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
+import { useTranslation } from "next-i18next";
 
 import { IRouletteState } from "types/IRouletteResult";
 
@@ -15,6 +16,7 @@ import {
   RoulettePlayContentTitle,
   RoulettePlayContentGenres,
   RoulettePlayContentBtn,
+  RoulettePlayContentImage,
 } from "./RoulettePlayContent.style";
 
 interface IRoulettePlayContentProps {
@@ -30,6 +32,8 @@ const RoulettePlayContent: React.FC<IRoulettePlayContentProps> = ({
   waiting,
   loading,
 }) => {
+  const { t } = useTranslation("main");
+
   const { error, data } = item;
 
   return (
@@ -38,38 +42,46 @@ const RoulettePlayContent: React.FC<IRoulettePlayContentProps> = ({
         <RoulettePlayContentCircle isPlay={!skip}>
           {data && !error && !loading ? (
             <RoulettePlayContentRandom>
-              <Image src={data.header_image} width={460} height={215} />
+              <RoulettePlayContentImage
+                src={data.header_image}
+                width={460}
+                height={215}
+              />
               <RoulettePlayContentBox>
-                <RoulettePlayContentTitle>
-                  {data.name || "이름없음."}
-                </RoulettePlayContentTitle>
+                <RoulettePlayContentTitle>{data.name}</RoulettePlayContentTitle>
                 <RoulettePlayContentGenres>
                   {data.genres.map((v, i) => (
                     <span key={i}>{v}</span>
                   ))}
                 </RoulettePlayContentGenres>
                 <Link href={`/about/${data.id}`} scroll={true}>
-                  <RoulettePlayContentBtn>게임 상세보기</RoulettePlayContentBtn>
+                  <RoulettePlayContentBtn>
+                    {t("main_roulette_game_info")}
+                  </RoulettePlayContentBtn>
                 </Link>
               </RoulettePlayContentBox>
             </RoulettePlayContentRandom>
           ) : (
             <RoulettePlayContentRandom>
               {waiting ? (
-                <Image src={loadingGif} width={30} height={30} />
+                <RoulettePlayContentImage
+                  src={loadingGif}
+                  width={30}
+                  height={30}
+                />
               ) : (
-                <Image src={random} />
+                <Image src={random} width={56} height={98} />
               )}
             </RoulettePlayContentRandom>
           )}
           <RoulettePlayContentRandom>
-            <Image src={random} />
+            <Image src={random} width={56} height={98} />
           </RoulettePlayContentRandom>
           <RoulettePlayContentRandom>
-            <Image src={random} />
+            <Image src={random} width={56} height={98} />
           </RoulettePlayContentRandom>
           <RoulettePlayContentRandom>
-            <Image src={random} />
+            <Image src={random} width={56} height={98} />
           </RoulettePlayContentRandom>
         </RoulettePlayContentCircle>
       </RoulettePlayContentGroup>


### PR DESCRIPTION
## What is this PR? 🔍

#57 완료.

## Major Fix 🔌

같은 `<Image />` 태그를 사용하여 이전에 width height 를 기억하여 깜빡거린 것 같습니다.
styled-components로 커스텀 스타을을 주어 수정하였습니다.


## Minor Fix 🛠
